### PR TITLE
Implement initial TAS MM bounty system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 *.csv
 venv
 helper_classes
+local/

--- a/constants/btt_constants.py
+++ b/constants/btt_constants.py
@@ -133,9 +133,94 @@ BTT_SUS_TAGS = {
 
 
     # 'NCS BSS' # NCS is its own categore, make sure NCS runs dont get categorized with suicide runs or completions
-    # e.g. if a NCS luigi exists, make sure the separate NCS and BSS tags dont interfere with it.   
+    # e.g. if a NCS luigi exists, make sure the separate NCS and BSS tags dont interfere with it.
     # 'no upb, no air dodge, 9 targets (x targets), no neuitral b, mr saturn, beam sword, bomb, no turnips, ar bomb, ar pokebolls , no upb, no pressing down, no nb,  '
     # 'top target first, all blocks/targets, no glitch'
     # 'full charge shot, bomb riddle', 'only zelda,', '5 ze 5sheik', 'no forward b', 'no projectiles hookshot','no damage', ''
-    
+
 }
+
+# ============================================================================
+# TAS MM Bounty System Constants
+# ============================================================================
+
+# List of (character, stage) tuples that are impossible to complete in
+#
+# Format: [('Character Name', 'Stage Name'), ...]
+#
+# These pairings will be excluded when randomly selecting new bounties.
+# Generated from RTA mismatch sheet - pairings with target counts instead of times
+IMPOSSIBLE_PAIRINGS = [
+    # Dr. Mario impossible pairings
+    (BTT_CHARACTERS[0], BTT_STAGES[17]),   # Dr. Mario × Young Link (1 target)
+
+    # Luigi impossible pairings
+    (BTT_CHARACTERS[2], BTT_STAGES[17]),   # Luigi × Young Link (1 target)
+
+    # Bowser impossible pairings
+    (BTT_CHARACTERS[3], BTT_STAGES[5]),    # Bowser × Yoshi (9 targets)
+    (BTT_CHARACTERS[3], BTT_STAGES[17]),   # Bowser × Young Link (1 target)
+    (BTT_CHARACTERS[3], BTT_STAGES[20]),   # Bowser × Jigglypuff (8 targets)
+
+    # Yoshi impossible pairings
+    (BTT_CHARACTERS[5], BTT_STAGES[17]),   # Yoshi × Young Link (1 target)
+    (BTT_CHARACTERS[5], BTT_STAGES[20]),   # Yoshi × Jigglypuff (9 targets)
+
+    # Donkey Kong impossible pairings
+    (BTT_CHARACTERS[6], BTT_STAGES[5]),    # Donkey Kong × Yoshi (9 targets)
+    (BTT_CHARACTERS[6], BTT_STAGES[17]),   # Donkey Kong × Young Link (1 target)
+
+    # Captain Falcon impossible pairings
+    (BTT_CHARACTERS[7], BTT_STAGES[20]),   # Captain Falcon × Jigglypuff (9 targets)
+
+    # Ganondorf impossible pairings
+    (BTT_CHARACTERS[8], BTT_STAGES[0]),    # Ganondorf × Dr. Mario (9 targets)
+    (BTT_CHARACTERS[8], BTT_STAGES[17]),   # Ganondorf × Young Link (0 targets)
+    (BTT_CHARACTERS[8], BTT_STAGES[20]),   # Ganondorf × Jigglypuff (8 targets)
+
+    # Falco impossible pairings
+    (BTT_CHARACTERS[9], BTT_STAGES[17]),   # Falco × Young Link (9 targets)
+
+    # Fox impossible pairings
+    (BTT_CHARACTERS[10], BTT_STAGES[17]),  # Fox × Young Link (9 targets)
+
+    # Ness impossible pairings
+    (BTT_CHARACTERS[11], BTT_STAGES[17]),  # Ness × Young Link (6 targets)
+
+    # Popo impossible pairings
+    (BTT_CHARACTERS[12], BTT_STAGES[5]),   # Popo × Yoshi (9 targets)
+    (BTT_CHARACTERS[12], BTT_STAGES[17]),  # Popo × Young Link (1 target)
+    (BTT_CHARACTERS[12], BTT_STAGES[20]),  # Popo × Jigglypuff (8 targets)
+
+    # Kirby impossible pairings
+    (BTT_CHARACTERS[14], BTT_STAGES[17]),  # Kirby × Young Link (1 target)
+
+    # Pikachu impossible pairings
+    (BTT_CHARACTERS[20], BTT_STAGES[17]),  # Pikachu × Young Link (1 target)
+
+    # Mr. Game & Watch impossible pairings
+    (BTT_CHARACTERS[23], BTT_STAGES[17]),  # Mr. Game & Watch × Young Link (1 target)
+    (BTT_CHARACTERS[23], BTT_STAGES[20]),  # Mr. Game & Watch × Jigglypuff (9 targets)
+
+    # Marth impossible pairings
+    (BTT_CHARACTERS[24], BTT_STAGES[17]),  # Marth × Young Link (1 target)
+
+    # Roy impossible pairings
+    (BTT_CHARACTERS[25], BTT_STAGES[17]),  # Roy × Young Link (1 target)
+    (BTT_CHARACTERS[25], BTT_STAGES[20]),  # Roy × Jigglypuff (9 targets)
+
+    # Zelda impossible pairings
+    (BTT_CHARACTERS[26], BTT_STAGES[17]),  # Zelda × Young Link (0 targets)
+    (BTT_CHARACTERS[26], BTT_STAGES[20]),  # Zelda × Jigglypuff (9 targets)
+
+    # Male Wireframe impossible pairings
+    (BTT_CHARACTERS[27], BTT_STAGES[17]),  # Male Wireframe × Young Link (1 target)
+    (BTT_CHARACTERS[27], BTT_STAGES[20]),  # Male Wireframe × Jigglypuff (9 targets)
+
+    # Female Wireframe impossible pairings
+    (BTT_CHARACTERS[28], BTT_STAGES[17]),  # Female Wireframe × Young Link (1 target)
+    (BTT_CHARACTERS[28], BTT_STAGES[20]),  # Female Wireframe × Jigglypuff (8 targets)
+
+    # Giga Bowser impossible pairings
+    (BTT_CHARACTERS[29], BTT_STAGES[17]),  # Giga Bowser × Young Link (1 target)
+]

--- a/helper_functions/bounty_helper_functions.py
+++ b/helper_functions/bounty_helper_functions.py
@@ -1,0 +1,213 @@
+"""
+Bounty System Helper Functions
+
+This module provides helper functions for the bounty run feature,
+including bounty selection, querying, and completion checking.
+"""
+
+import secrets
+from db import connect
+from constants.btt_constants import BTT_CHARACTERS, BTT_STAGES, IMPOSSIBLE_PAIRINGS
+
+
+def get_uncompleted_tas_mismatches():
+    """
+    Query all mismatch pairings (character != stage) that do NOT have
+    any TAS records in btt_table.
+
+    Returns:
+        list: List of (character, stage) tuples representing uncompleted tas mm
+            Empty list if all tas mm are completed
+    """
+    conn = connect()
+    cur = conn.cursor()
+
+    # Get all possible mismatch pairings (character != stage)
+    # Use special characters (30) and standard stages (25)
+    characters = BTT_CHARACTERS[:30]
+    standard_stages = BTT_STAGES[:25]
+
+    all_mismatches = [
+        (char, stage)
+        for char in characters
+        for stage in standard_stages
+        if char != stage  # Exclude matching pairings
+    ]
+
+    # Remove impossible pairings from consideration
+    impossible_mm = set(IMPOSSIBLE_PAIRINGS)
+    possible_mismatches = [
+        pairing for pairing in all_mismatches
+        if pairing not in impossible_mm
+    ]
+
+    # Query database for all mismatch pairings that already have TAS records
+    sql = """
+        SELECT DISTINCT character, stage
+        FROM btt_table
+        WHERE tas = TRUE
+        AND character != stage
+    """
+    cur.execute(sql)
+    completed_pairings = set((row[0], row[1]) for row in cur.fetchall())
+
+    conn.close()
+
+    # Return only pairings that have NOT been completed
+    uncompleted = [
+        pairing for pairing in possible_mismatches
+        if pairing not in completed_pairings
+    ]
+
+    return uncompleted
+
+
+def select_new_bounty():
+    """
+    Randomly select a new bounty from uncompleted TAS mismatches and
+    save it to the database.
+
+    Returns:
+        tuple or None: (character, stage) of the new bounty, or None if all
+            tas mm have been completed
+    """
+    uncompleted = get_uncompleted_tas_mismatches()
+
+    if not uncompleted:
+        # All tas mm have been completed!
+        return None
+
+    new_bounty = secrets.choice(uncompleted)
+
+    conn = connect()
+    cur = conn.cursor()
+
+    # # Update database with new tas mm bounty
+    sql = """
+        UPDATE bounty_state
+        SET character = %s, stage = %s, created_date = NOW()
+        WHERE id = 1
+    """
+    cur.execute(sql, (new_bounty[0], new_bounty[1]))
+    conn.commit()
+    conn.close()
+
+    return new_bounty
+
+
+def get_current_bounty():
+    """
+    Retrieve the current active bounty pairing from the database.
+    """
+    conn = connect()
+    cur = conn.cursor()
+
+    sql = """
+        SELECT character, stage, created_date
+        FROM bounty_state
+        WHERE id = 1
+    """
+    cur.execute(sql)
+    row = cur.fetchone()
+    conn.close()
+
+    if not row:
+        return None
+
+    return {
+        'character': row[0],
+        'stage': row[1],
+        'created_date': row[2]
+    }
+
+
+def initialize_bounty():
+    """
+    Initialize the bounty system by inserting the first random bounty.
+
+    This should only be called once during setup, or if the bounty_state
+    table is empty.
+    """
+    uncompleted = get_uncompleted_tas_mismatches()
+
+    if not uncompleted:
+        # All bounties already completed (unlikely on first init)
+        return None
+
+    first_bounty = secrets.choice(uncompleted)
+
+    conn = connect()
+    cur = conn.cursor()
+
+    sql = """
+        INSERT INTO bounty_state (id, character, stage, created_date)
+        VALUES (1, %s, %s, NOW())
+    """
+    cur.execute(sql, (first_bounty[0], first_bounty[1]))
+    conn.commit()
+    conn.close()
+
+    return first_bounty
+
+
+def matches_current_bounty(character, stage):
+    current = get_current_bounty()
+
+    if not current:
+        return False
+
+    return (current['character'] == character and current['stage'] == stage)
+
+
+def get_bounty_progress():
+    """
+    Calculate how many bounties have been completed vs total possible.
+
+    Returns:
+        dict: Dictionary with keys:
+            - 'completed': Number of completed TAS mismatch records
+            - 'total': Total possible (725 minus impossible pairings)
+            - 'remaining': Number of uncompleted runs
+
+    Example:
+        >>> progress = get_bounty_progress()
+        >>> print(f"{progress['completed']}/{progress['total']} bounties completed")
+    """
+    uncompleted = get_uncompleted_tas_mismatches()
+    remaining = len(uncompleted)
+    total_possible = 725 - len(IMPOSSIBLE_PAIRINGS)
+    completed = total_possible - remaining
+
+    return {
+        'completed': completed,
+        'total': total_possible,
+        'remaining': remaining
+    }
+
+
+def is_bounty_already_completed():
+    """
+    Check if the current active bounty already has TAS records in the database.
+
+    This can happen if:
+    - The database was manually edited
+    - A record was added but the bounty wasn't updated
+    - There's a data inconsistency
+    """
+    current = get_current_bounty()
+
+    if not current:
+        return False
+
+    conn = connect()
+    cur = conn.cursor()
+
+    sql = """
+        SELECT COUNT(*) FROM btt_table
+        WHERE character = %s AND stage = %s AND tas = TRUE
+    """
+    cur.execute(sql, (current['character'], current['stage']))
+    count = cur.fetchone()[0]
+    conn.close()
+
+    return count > 0


### PR DESCRIPTION
# TAS Mismatch Bounty System

## Summary

This PR implements a persistent bounty system for BTT TAS mismatch runs. The system tracks a single "current bounty" - a random uncompleted TAS mismatch pairing, and automatically updates to a new random bounty when players submit the first TAS record for that pairing.

## Changes Overview

### New Files

**`helper_functions/bounty_helper_functions.py`**
Core bounty system logic with the following functions:
- `get_uncompleted_tas_mismatches()` - Queries all mismatch pairings without TAS records
- `select_new_bounty()` - Randomly selects and saves a new bounty
- `get_current_bounty()` - Retrieves the active bounty from database
- `initialize_bounty()` - First-time setup for the bounty system
- `matches_current_bounty()` - Validates if a submission completes the active bounty
- `get_bounty_progress()` - Calculates completion statistics (completed/total/remaining)
- `is_bounty_already_completed()` - Checks for data inconsistencies (active bounty is existing run)

### Modified Files

**`commands/btt_commands.py`**
Added public user commands:
- `/bounty` - View current bounty with character, stage, issue date, and progress statistics
- `/bounty-stats` - View completion statistics and overall progress

**`commands/owner_commands.py`**
Added admin commands and automatic bounty updates:
- `/bounty-init` - Initialize the bounty system (first-time setup, owner-only)
- `/bounty-refresh` - Manually reroll to a new bounty (owner-only)
- Modified `/add-btt-record` - Auto-detects bounty completion and updates to next bounty

**`constants/btt_constants.py`**
Added `IMPOSSIBLE_PAIRINGS` constant:
- List of 34 character/stage combinations that cannot be completed, sourced from RTA mismatch sheet data
- Prevents impossible pairings from being selected as bounties

**`.gitignore`**
Added local directory to gitignore (staging area for documentation + files)

## Technical Implementation

### Database Schema

A new `bounty_state` table is required:

```sql
CREATE TABLE bounty_state (
    id INTEGER PRIMARY KEY DEFAULT 1,
    character TEXT NOT NULL,
    stage TEXT NOT NULL,
    created_date TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
    CONSTRAINT single_row CHECK (id = 1)
);
```

The `single_row` constraint ensures only one active bounty exists at any time.

### Bounty Selection Algorithm

1. Query all 30 characters × 25 stages where character ≠ stage = 725 total mismatches
2. Exclude pairings from `IMPOSSIBLE_PAIRINGS` (34 impossible runs) = 691 valid mismatches
3. Query `btt_table` for existing TAS mismatch records
4. Filter out completed pairings from valid mismatches
5. Update `bounty_state` table with new bounty and timestamp

### Auto-Update Flow

When a BTT record is submitted via `/add-btt-record`:

1. Record is inserted into `btt_table` (existing behavior)
2. **New:** System checks if submission is:
   - A TAS record (`tas=TRUE`)
   - A mismatch (`character != stage`)
   - The current bounty (`matches_current_bounty()`)
3. If all conditions are met:
   - Call `select_new_bounty()` to choose next random uncompleted run
   - Append bounty completion message to submission response
   - Handle edge case: display celebration if this was the final bounty

### Error Handling

- Bounty update failures during record submission won't affect the record being saved
- Admin can manually fix stuck states with `/bounty-refresh`
- Validation prevents initialization when bounty already exists

## Usage

### Initial Setup (Admin Only)

1. Deploy database schema: `psql $DATABASE_URL -f schema_bounty.sql` (this is just what claude says I didn't not set up postgres)
2. Deploy code changes
3. Run `/bounty-init` in Discord to create first random bounty

### User Commands

```
/bounty          # View current bounty with progress stats
/bounty-stats    # View completion statistics
```

### Admin Commands

```
/bounty-init     # Initialize system (first-time only)
/bounty-refresh  # Manually reroll to new bounty
/add-btt-record  # Works as before + auto-updates bounties
```

## Example Output

**Bounty Completion During Record Submission:**
```
Improved BTT TAS record: Mario/Luigi from 3.45 by Player1 to 3.23 by Player2
Mario character TAS total improved from 42.15 to 41.93
Luigi stage TAS total improved from 45.67 to 45.45

🎯 BOUNTY COMPLETED!
New bounty: Fox on Falco stage
```

**Final Bounty Completion:**
```
Added BTT TAS record: Zelda/Peach - 4.56 by Player3

🎉 ALL BOUNTIES COMPLETED! This was the last uncompleted TAS mismatch!
```
