### PR TITLE
display current RTA record when creating new bounty

### DIFF
--- a/commands/owner_commands.py
+++ b/commands/owner_commands.py
@@ -10,7 +10,7 @@ from helper_functions.btt_helper_functions import get_stage_total, get_char_tota
 from helper_functions.event_helper_functions import get_current_event_wr, get_event_total
 from helper_functions.hrc_helper_functions import get_current_hrc_wr, get_hrc_total
 from helper_functions.ten_mm_helper_functions import get_current_10mm_wr, get_10mm_total
-from helper_functions.bounty_helper_functions import initialize_bounty, select_new_bounty, matches_current_bounty, get_current_bounty
+from helper_functions.bounty_helper_functions import initialize_bounty, select_new_bounty, matches_current_bounty, get_current_bounty, get_rta_wr_video
 import embeds
 
 from interactions import Client, CommandContext, Permissions, Option, OptionType, Choice
@@ -204,6 +204,12 @@ def register_owner_commands(bot: Client):
                     new_bounty = select_new_bounty()
                     if new_bounty:
                         bounty_message = f'\n\n🎯 **BOUNTY COMPLETED!**\nNew bounty: **{new_bounty[0]}** on **{new_bounty[1]}** stage'
+                        try:
+                            wr_video = get_rta_wr_video(new_bounty[0], new_bounty[1])
+                            if wr_video:
+                                bounty_message += f'\nCurrent RTA WR: {wr_video}'
+                        except Exception:
+                            pass
                     else:
                         bounty_message = f'\n\n🎉 **ALL BOUNTIES COMPLETED!** This was the last uncompleted TAS mismatch!'
                 except Exception as e:
@@ -847,6 +853,12 @@ def register_owner_commands(bot: Client):
                 return None
 
             description = f"✅ **Bounty System Initialized!**\n\nFirst bounty: **{first_bounty[0]}** on **{first_bounty[1]}** stage\n\nUsers can now use `/bounty` to view the current bounty."
+            try:
+                wr_video = get_rta_wr_video(first_bounty[0], first_bounty[1])
+                if wr_video:
+                    description += f'\n\nCurrent RTA WR: {wr_video}'
+            except Exception:
+                pass
             await ctx.send(description)
 
         except Exception as e:
@@ -892,6 +904,12 @@ def register_owner_commands(bot: Client):
                 return None
 
             description = f"🔄 **Bounty Refreshed!**\n\nPrevious: **{old_char}** on **{old_stage}**\nNew: **{new_bounty[0]}** on **{new_bounty[1]}**"
+            try:
+                wr_video = get_rta_wr_video(new_bounty[0], new_bounty[1])
+                if wr_video:
+                    description += f'\n\nCurrent RTA WR: {wr_video}'
+            except Exception:
+                pass
             await ctx.send(description)
 
         except Exception as e:

--- a/helper_functions/bounty_helper_functions.py
+++ b/helper_functions/bounty_helper_functions.py
@@ -8,6 +8,7 @@ including bounty selection, querying, and completion checking.
 import secrets
 from db import connect
 from constants.btt_constants import BTT_CHARACTERS, BTT_STAGES, IMPOSSIBLE_PAIRINGS
+from helper_functions.btt_helper_functions import filter_btt_tags
 
 
 def get_uncompleted_tas_mismatches():
@@ -183,6 +184,40 @@ def get_bounty_progress():
         'total': total_possible,
         'remaining': remaining
     }
+
+
+def get_rta_wr_video(character, stage):
+    """
+    Return the YouTube URL of the current RTA (non-TAS) WR for a pairing,
+    or None if no RTA record exists.
+
+    Kept separate from get_current_btt_wr because that helper has side
+    effects on the no-record path and returns more than we need here.
+    """
+    conn = connect()
+    try:
+        cur = conn.cursor()
+        sql = """
+            SELECT * FROM btt_table
+            WHERE character = %s AND stage = %s AND tas = FALSE
+            ORDER BY score ASC, date ASC
+        """
+        cur.execute(sql, (character, stage))
+        # Apply the same default tag filtering /btt-wr uses so we don't
+        # surface a record (1T, misfire, AR, LSS/BSS/RSS/TSS) that the
+        # canonical WR query would reject.
+        records = filter_btt_tags([], cur)
+    finally:
+        conn.close()
+
+    if not records:
+        return None
+
+    sources = records[0][4]
+    if not sources:
+        return None
+
+    return sources[0]
 
 
 def is_bounty_already_completed():


### PR DESCRIPTION
This always feels like the natural step to take after a new bounty is displayed, so we should just do it automatically.

I also still haven't gone through the setup to be able to test things out fully end to end locally, so I may ask to lean a bit on Mega to test things out again if possible.

If I have some time in the next few days I may look to put up a PR to refactor things to better accommodate a mocked DB layer for local use.